### PR TITLE
First draft of template for new content libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,20 @@
+lazy val template = (project in file("."))
+    .enablePlugins(ExerciseCompilerPlugin)
+    .settings(
+      organization := "org.scala-exercises",
+      name         := "exercises-template",
+      scalaVersion := "2.11.8",
+      version := "0.2.2-SNAPSHOT",
+      resolvers ++= Seq(
+        Resolver.sonatypeRepo("snapshots"),
+        Resolver.sonatypeRepo("releases")
+      ),
+      libraryDependencies ++= Seq(
+        "org.scalatest" %% "scalatest" % "2.2.4",
+        "org.scala-exercises" %% "exercise-compiler" % version.value,
+        "org.scala-exercises" %% "definitions" % version.value,
+        "org.scalacheck" %% "scalacheck" % "1.12.5",
+        "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1",
+        compilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
+      )
+    )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.2.2-SNAPSHOT", "0.13", "2.10")

--- a/src/main/scala/templatelib/MyLibrary.scala
+++ b/src/main/scala/templatelib/MyLibrary.scala
@@ -1,0 +1,16 @@
+package templatelib
+import org.scalaexercises.definitions._
+
+/** This is the description of the library as it will appear in the Scala Exercises website.
+  *
+  * @param name template
+  */
+object MyLibrary extends Library {
+  override def owner = "scala-exercises"
+  override def repository = "scala-exercises"
+  override def color = Some("#323232")
+
+  override def sections = List(
+    SectionA
+  )
+}

--- a/src/main/scala/templatelib/SectionA.scala
+++ b/src/main/scala/templatelib/SectionA.scala
@@ -1,0 +1,30 @@
+package templatelib
+
+import org.scalatest._
+import org.scalaexercises.definitions._
+
+/** @param name section_title
+  */
+
+object SectionA extends FlatSpec with Matchers with Section {
+  /** = Exercise block title =
+    *
+    * Text describing background about the exercise, can be as long as needed.
+    *
+    * {{{
+    *   // Scala code blocks can also be added to enhance your documentation.
+    * }}}
+    *
+    * Also, documentation can be broken in as many paragraphs as necessary.
+    */
+  def functionAssert(res0: Boolean): Unit = {
+    true shouldBe res0
+  }
+
+  /** And obviously you can add as many documentation and exercises as you need
+    * to make your point ;-).
+    */
+  def functionFalseAssert(res0: Boolean): Unit = {
+    false shouldBe res0
+  }
+}

--- a/src/test/scala/templatelib/MyLibrarySpec.scala
+++ b/src/test/scala/templatelib/MyLibrarySpec.scala
@@ -1,7 +1,5 @@
 package templatelib
 
-package fpinscalalib
-
 import org.scalacheck.Shapeless._
 import org.scalaexercises.Test
 import org.scalatest.Spec

--- a/src/test/scala/templatelib/MyLibrarySpec.scala
+++ b/src/test/scala/templatelib/MyLibrarySpec.scala
@@ -1,0 +1,19 @@
+package templatelib
+
+package fpinscalalib
+
+import org.scalacheck.Shapeless._
+import org.scalaexercises.Test
+import org.scalatest.Spec
+import org.scalatest.prop.Checkers
+import shapeless.HNil
+
+class MyLibrarySpec extends Spec with Checkers {
+  def `function asserts` = {
+    check(Test.testSuccess(SectionA.functionAssert _, true :: HNil))
+  }
+
+  def `function false asserts` = {
+    check(Test.testSuccess(SectionA.functionFalseAssert _, false :: HNil))
+  }
+}


### PR DESCRIPTION
Fixes #552 (https://github.com/scala-exercises/scala-exercises/issues/552)

This PR adds a bare-bones content library to help developers to create new content for Scala Excercises. Built following the steps described in the Developer Guide (https://github.com/scala-exercises/scala-exercises/blob/master/DEV_GUIDE.md).

Could you please review, @dialelo @raulraja @juanpedromoreno? Thanks a lot!