### PR TITLE
Update to Scala 2.12.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,25 @@
+val scalaExercisesV = "0.5.0-SNAPSHOT"
+
+def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
+
 lazy val template = (project in file("."))
-    .enablePlugins(ExerciseCompilerPlugin)
-    .settings(
-      organization := "org.scala-exercises",
-      name         := "exercises-template",
-      scalaVersion := "2.11.8",
-      version := "0.2.2-SNAPSHOT",
-      resolvers ++= Seq(
-        Resolver.sonatypeRepo("snapshots"),
-        Resolver.sonatypeRepo("releases")
-      ),
-      libraryDependencies ++= Seq(
-        "org.scalatest" %% "scalatest" % "2.2.4",
-        "org.scala-exercises" %% "exercise-compiler" % version.value,
-        "org.scala-exercises" %% "definitions" % version.value,
-        "org.scalacheck" %% "scalacheck" % "1.12.5",
-        "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1",
-        compilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
-      )
-    )
+  .enablePlugins(ExerciseCompilerPlugin)
+  .settings(
+    organization := "org.scala-exercises",
+    name := "exercises-template",
+    scalaVersion := "2.12.10",
+    version := "0.5.0-SNAPSHOT",
+    resolvers ++= Seq(
+      Resolver.sonatypeRepo("snapshots"),
+      Resolver.sonatypeRepo("releases")
+    ),
+    libraryDependencies ++= Seq(
+      dep("exercise-compiler"),
+      dep("definitions"),
+      %%("shapeless", "2.3.3"),
+      %%("scalatest", "3.0.8"),
+      %%("scalacheck", "1.14.2"),
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.3"
+    ),
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.2.2-SNAPSHOT", "0.13", "2.10")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.12.0-M3")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.5.0-SNAPSHOT")

--- a/src/main/scala/templatelib/MyLibrary.scala
+++ b/src/main/scala/templatelib/MyLibrary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package templatelib
 import org.scalaexercises.definitions._
 
@@ -13,4 +29,6 @@ object MyLibrary extends Library {
   override def sections = List(
     SectionA
   )
+
+  override def logoPath = ""
 }

--- a/src/main/scala/templatelib/SectionA.scala
+++ b/src/main/scala/templatelib/SectionA.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package templatelib
 
 import org.scalatest._
@@ -5,8 +21,8 @@ import org.scalaexercises.definitions._
 
 /** @param name section_title
   */
-
 object SectionA extends FlatSpec with Matchers with Section {
+
   /** = Exercise block title =
     *
     * Text describing background about the exercise, can be as long as needed.

--- a/src/test/scala/templatelib/MyLibrarySpec.scala
+++ b/src/test/scala/templatelib/MyLibrarySpec.scala
@@ -1,12 +1,28 @@
+/*
+ * Copyright 2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package templatelib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class MyLibrarySpec extends Spec with Checkers {
+class MyLibrarySpec extends RefSpec with Checkers {
   def `function asserts` = {
     check(Test.testSuccess(SectionA.functionAssert _, true :: HNil))
   }


### PR DESCRIPTION
This PR updates Scala version to 2.12.10 and updates dependency versions. Makes compatibility with version 0.5.0-SNAPSHOT of Scala Exercises.