### PR TITLE
Updated ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,10 @@ lazy val template = (project in file("."))
       dep("exercise-compiler"),
       dep("definitions"),
       %%("shapeless", "2.3.3"),
-      %%("scalatest", "3.0.8"),
+      %%("scalatest", "3.1.0"),
       %%("scalacheck", "1.14.2"),
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.3"
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.3",
+      "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2"
     ),
     addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)
   )

--- a/src/main/scala/templatelib/SectionA.scala
+++ b/src/main/scala/templatelib/SectionA.scala
@@ -16,12 +16,13 @@
 
 package templatelib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 import org.scalaexercises.definitions._
+import org.scalatest.flatspec.AnyFlatSpec
 
 /** @param name section_title
   */
-object SectionA extends FlatSpec with Matchers with Section {
+object SectionA extends AnyFlatSpec with Matchers with Section {
 
   /** = Exercise block title =
     *


### PR DESCRIPTION
This PR updates ScalaTest dependency to version 3.1.0.